### PR TITLE
Revert "bump ffmpeg to 4.2.1"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ apt-get $APT_OPTIONS update >/dev/null
 apt-get $APT_OPTIONS -y -d install --reinstall poppler-utils >/dev/null
 echo -n '.'
 
-SFFMPEG_VERSION="4.2.1"
+SFFMPEG_VERSION="4.0.0-1"
 SFFMPEG_FILENAME="sffmpeg_${SFFMPEG_VERSION}_amd64.deb"
 curl -sL -o "$APT_CACHE_DIR/archives/$SFFMPEG_FILENAME" "https://heroku-activestorage-default.s3.amazonaws.com/sffmpeg/$SFFMPEG_FILENAME"
 echo -n '.'


### PR DESCRIPTION
Reverts heroku/heroku-buildpack-activestorage-preview#8

There's an error in the new ffmpeg build with how libaom was included. Reverting for now to address #9 until it's resolved. 