### PR TITLE
Revert "Revert "bump ffmpeg to 4.2.1""

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ apt-get $APT_OPTIONS update >/dev/null
 apt-get $APT_OPTIONS -y -d install --reinstall poppler-utils >/dev/null
 echo -n '.'
 
-SFFMPEG_VERSION="4.0.0-1"
+SFFMPEG_VERSION="4.2.1"
 SFFMPEG_FILENAME="sffmpeg_${SFFMPEG_VERSION}_amd64.deb"
 curl -sL -o "$APT_CACHE_DIR/archives/$SFFMPEG_FILENAME" "https://heroku-activestorage-default.s3.amazonaws.com/sffmpeg/$SFFMPEG_FILENAME"
 echo -n '.'

--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ apt-get $APT_OPTIONS update >/dev/null
 apt-get $APT_OPTIONS -y -d install --reinstall poppler-utils >/dev/null
 echo -n '.'
 
-SFFMPEG_VERSION="4.2.1"
+SFFMPEG_VERSION="4.2.1-1"
 SFFMPEG_FILENAME="sffmpeg_${SFFMPEG_VERSION}_amd64.deb"
 curl -sL -o "$APT_CACHE_DIR/archives/$SFFMPEG_FILENAME" "https://heroku-activestorage-default.s3.amazonaws.com/sffmpeg/$SFFMPEG_FILENAME"
 echo -n '.'


### PR DESCRIPTION
Reverts heroku/heroku-buildpack-activestorage-preview#10

sffmpeg 4.2.1 has been rebuilt to address the previous bug in #9 
https://github.com/heroku/sffmpeg/pull/5 