### PR TITLE
bump to rebuilt ffmpeg 4.2.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -52,7 +52,6 @@ apt-get $APT_OPTIONS update >/dev/null
 apt-get $APT_OPTIONS -y -d install --reinstall poppler-utils >/dev/null
 echo -n '.'
 
-SFFMPEG_VERSION="4.2.1-2"
 SFFMPEG_FILENAME="sffmpeg_${SFFMPEG_VERSION}_amd64.deb"
 curl -sL -o "$APT_CACHE_DIR/archives/$SFFMPEG_FILENAME" "https://heroku-activestorage-default.s3.amazonaws.com/sffmpeg/$SFFMPEG_FILENAME"
 echo -n '.'

--- a/bin/compile
+++ b/bin/compile
@@ -34,9 +34,9 @@ APT_CACHE_DIR="$CACHE_DIR/.heroku/activestorage-preview/cache"
 APT_STATE_DIR="$CACHE_DIR/.heroku/activestorage-preview/state"
 
 if [ -f $CACHE_DIR/.apt/SFFMPEG ] && [[ $CACHED_SFFMPEG == $SFFMPEG_VERSION ]] ; then
-	echo -n 'Reusing cache' | indent
+	echo 'Reusing cache' | indent
 else
-	echo -n 'Detected ffmpeg version change, flushing cache' | indent
+	echo 'Detected ffmpeg version change, flushing cache' | indent
 	rm -rf $APT_CACHE_DIR
 	mkdir -p "$APT_CACHE_DIR/archives/partial"
 	mkdir -p "$APT_CACHE_DIR/lists/partial"

--- a/bin/compile
+++ b/bin/compile
@@ -17,11 +17,30 @@ function indent() {
 
 echo '-----> Installing binary dependencies for ActiveStorage Preview'
 
+SFFMPEG_VERSION="4.2.1-2"
+
+# Store which ffmpeg version was installed in the cache to bust the cache if it changes
+if [ -f $CACHE_DIR/.apt/SFFMPEG ]; then
+	CACHED_SFFMPEG=$(cat "$CACHE_DIR/.apt/SFFMPEG")
+else
+	CACHED_SFFMPEG=$SFFMPEG_VERSION
+fi
+
+# Ensure we store the ffmpeg version in the cache for next time.
+mkdir -p "$CACHE_DIR/.apt"
+echo "$SFFMPEG_VERSION" > "$CACHE_DIR/.apt/SFFMPEG"
+
 APT_CACHE_DIR="$CACHE_DIR/.heroku/activestorage-preview/cache"
 APT_STATE_DIR="$CACHE_DIR/.heroku/activestorage-preview/state"
 
-mkdir -p "$APT_CACHE_DIR/archives/partial"
-mkdir -p "$APT_STATE_DIR/lists/partial"
+if [ -f $CACHE_DIR/.apt/SFFMPEG ] && [[ $CACHED_SFFMPEG == $SFFMPEG_VERSION ]] ; then
+	echo -n 'Reusing cache' | indent
+else
+	echo -n 'Detected ffmpeg version change, flushing cache' | indent
+	rm -rf $APT_CACHE_DIR
+	mkdir -p "$APT_CACHE_DIR/archives/partial"
+	mkdir -p "$APT_CACHE_DIR/lists/partial"
+fi
 
 APT_OPTIONS="-o debug::nolocking=true"
 APT_OPTIONS="$APT_OPTIONS -o dir::cache=$APT_CACHE_DIR"

--- a/bin/compile
+++ b/bin/compile
@@ -26,10 +26,6 @@ else
 	CACHED_SFFMPEG=$SFFMPEG_VERSION
 fi
 
-# Ensure we store the ffmpeg version in the cache for next time.
-mkdir -p "$CACHE_DIR/.apt"
-echo "$SFFMPEG_VERSION" > "$CACHE_DIR/.apt/SFFMPEG"
-
 APT_CACHE_DIR="$CACHE_DIR/.heroku/activestorage-preview/cache"
 APT_STATE_DIR="$CACHE_DIR/.heroku/activestorage-preview/state"
 
@@ -41,6 +37,10 @@ else
 	mkdir -p "$APT_CACHE_DIR/archives/partial"
 	mkdir -p "$APT_CACHE_DIR/lists/partial"
 fi
+
+# Ensure we store the ffmpeg version in the cache for next time.
+mkdir -p "$CACHE_DIR/.apt"
+echo "$SFFMPEG_VERSION" > "$CACHE_DIR/.apt/SFFMPEG"
 
 APT_OPTIONS="-o debug::nolocking=true"
 APT_OPTIONS="$APT_OPTIONS -o dir::cache=$APT_CACHE_DIR"

--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ apt-get $APT_OPTIONS update >/dev/null
 apt-get $APT_OPTIONS -y -d install --reinstall poppler-utils >/dev/null
 echo -n '.'
 
-SFFMPEG_VERSION="4.2.1-1"
+SFFMPEG_VERSION="4.2.1-2"
 SFFMPEG_FILENAME="sffmpeg_${SFFMPEG_VERSION}_amd64.deb"
 curl -sL -o "$APT_CACHE_DIR/archives/$SFFMPEG_FILENAME" "https://heroku-activestorage-default.s3.amazonaws.com/sffmpeg/$SFFMPEG_FILENAME"
 echo -n '.'


### PR DESCRIPTION
~**Do not merge before https://github.com/heroku/sffmpeg/pull/8**~ New ffmpeg has been released and this is ready.

This should resolve the issues with glibc incompatibility on the heroku-16 stack once the new ffmpeg build is available. 
