### PR TITLE
Upgrade ffmpeg to 4.2.3

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,7 +17,7 @@ function indent() {
 
 echo '-----> Installing binary dependencies for ActiveStorage Preview'
 
-SFFMPEG_VERSION="4.2.1-2"
+SFFMPEG_VERSION="4.2.3"
 
 # Store which ffmpeg version was installed in the cache to bust the cache if it changes
 if [ -f $CACHE_DIR/.apt/SFFMPEG ]; then


### PR DESCRIPTION
The static ffmpeg build has been upgraded to use ffmpeg 4.2.3 https://github.com/heroku/sffmpeg/pull/9

This PR bumps the version used by the buildpack to use the latest ffmpeg.

Tested with the active storage example app and this buildpack branch

```
~ $ ffmpeg
ffmpeg version 4.2.3 Copyright (c) 2000-2020 the FFmpeg developers
  built with gcc 5.4.0 (Ubuntu 5.4.0-6ubuntu1~16.04.12) 20160609
```

![Screen Shot 2020-06-12 at 11 51 39 AM](https://user-images.githubusercontent.com/419708/84521517-1af2fc00-aca3-11ea-9c49-d94550a0ba92.png)
