### PR TITLE
Use poppler-utils from stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+- Do not install Poppler utils, they are now on the stack image (https://github.com/heroku/heroku-buildpack-activestorage-preview/pull/32)
 - Upgrade FFMPEG to version 5.1.2 (https://github.com/heroku/heroku-buildpack-activestorage-preview/pull/30)
 - Include build formula for FFMPEG, now linking dynamically against newly added [stack image packages](https://devcenter.heroku.com/changelog-items/2547) (https://github.com/heroku/heroku-buildpack-activestorage-preview/pull/28)

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 This is an [official Heroku buildpack](https://devcenter.heroku.com/articles/language-support-policy#supported-buildpacks) to support Rails 5.2 users of [Active Storage previews](https://devcenter.heroku.com/articles/active-storage-on-heroku).
 
-One of the marquee features of Active Storage is the ability to use “previews” of non-image attachments. Specifically you can preview PDFs and Videos. To use this feature your application needs access to system resources that know how to work with these files. By default Rails ships with support with poppler for PDF previews, and ffmpeg for Video previews. These system dependencies are not available by default on Heroku.
+One of the marquee features of Active Storage is the ability to use “previews” of non-image attachments. Specifically you can preview PDFs and Videos. To use this feature your application needs access to system resources that know how to work with these files. By default Rails ships with support for two PDF libraries, one of which is available on Heroku, and it can use FFMPEG for Video previews, which is not available by default on Heroku.
 
-If you want the ability to preview these types of files with Active Support you need to run:
+If you want the ability to preview video files with Active Support you need to run:
 
 ```term
 heroku buildpacks:add -i 1 https://github.com/heroku/heroku-buildpack-activestorage-preview
 ```
 
-Once you’ve done this, you need to deploy again to get the binaries. You can verify that the dependencies are installed by running which ffmpeg on the command line. If there is no output then the operation was not performed correctly. If you see a result then the binaries are ready to be used:
+Once you’ve done this, you need to deploy again to get the binaries. You can verify that the dependencies are installed by running `which ffmpeg` on the command line. If there is no output then the operation was not performed correctly. If you see a result then the binaries are ready to be used:
 
 ```
 heroku run bash
 ~$ which ffmpeg
-/usr/local/bin/ffmpeg
+/app/.heroku/activestorage-preview/bin/ffmpeg
 ```
 
 ## Development

--- a/bin/compile
+++ b/bin/compile
@@ -38,42 +38,12 @@ echo '-----> Installing binary dependencies for ActiveStorage Preview'
 INSTALL_DIR="$BUILD_DIR/.heroku/activestorage-preview"
 mkdir -p "$INSTALL_DIR"
 
-APT_CACHE_DIR="/tmp/.heroku/activestorage-preview/cache"
-mkdir -p "$APT_CACHE_DIR/archives/partial"
-
-APT_STATE_DIR="/tmp/.heroku/activestorage-preview/state"
-mkdir -p "$APT_STATE_DIR/lists/partial"
-
-APT_OPTIONS="-o debug::nolocking=true"
-APT_OPTIONS="$APT_OPTIONS -o dir::cache=$APT_CACHE_DIR"
-APT_OPTIONS="$APT_OPTIONS -o dir::state=$APT_STATE_DIR"
-APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=/etc/apt/sources.list"
-
-if [[ $STACK == "heroku-18" ]]; then
-  LIBPOPPLER="libpoppler73"
-elif [[ $STACK == "heroku-20" ]]; then
-  LIBPOPPLER="libpoppler97"
-else
-  LIBPOPPLER="libpoppler118"
-fi
-
-echo 'Downloading latest poppler' | indent
-apt-get $APT_OPTIONS update >/dev/null
-apt-get $APT_OPTIONS -y -d install --reinstall poppler-utils "$LIBPOPPLER" libnss3 libnspr4 >/dev/null
-
-echo 'Installing poppler' | indent
-for deb in "$APT_CACHE_DIR"/archives/*.deb; do
-  dpkg -x "$deb" "$INSTALL_DIR"
-done
-echo 'Done' | indent
-
 echo "Downloading ffmpeg version $FFMPEG_VERSION" | indent
 curl_retry_on_18 -s --fail --retry 3 --retry-connrefused --connect-timeout "${CURL_CONNECT_TIMEOUT:-3}" "$INSTALL_URL" | tar xvz -C "$INSTALL_DIR" >/dev/null 2>&1
 echo 'Installing ffmpeg' | indent
 echo 'Done' | indent
 
 paths=$(cd "$BUILD_DIR" && find ./.heroku/activestorage-preview -iregex '.*/bin' -type d)
-library_paths=$(cd "$BUILD_DIR" && find ./.heroku/activestorage-preview -iregex '.*\.so\(\.[0-9]+\)*' | xargs -r -n 1 dirname | sort | uniq)
 
 echo 'Exporting environment variables' | indent
 # Write profile.d script for run time support
@@ -81,17 +51,8 @@ mkdir -p "$BUILD_DIR/.profile.d"
 cat <<EOF >"$BUILD_DIR/.profile.d/000_activestorage_preview.sh"
 export PATH="$(echo "$paths" | xargs -n 1 | sed 's/^./$HOME/' | paste -s -d ':' -):\$PATH"
 EOF
-if [[ -n "$library_paths" ]]; then
-cat <<EOF >>"$BUILD_DIR/.profile.d/000_activestorage_preview.sh"
-  export LD_LIBRARY_PATH="$(echo "$library_paths" | xargs -n 1 | sed 's/^./$HOME/' | paste -s -d ':' -):\$LD_LIBRARY_PATH"
-EOF
-fi
 
 # Export to other buildpacks for build time support
 export PATH="$(echo "$paths" | xargs -n 1 | sed "s/^./${BUILD_DIR//\//\\/}/" | paste -s -d ':' -)${PATH:+:}${PATH:-}"
-if [[ -n "$library_paths" ]]; then
-  export LD_LIBRARY_PATH="$(echo "$library_paths" | xargs -n 1 | sed "s/^./${BUILD_DIR//\//\\/}/" | paste -s -d ':' -)${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH:-}"
-  export LIBRARY_PATH="$(echo "$library_paths" | xargs -n 1 | sed "s/^./${BUILD_DIR//\//\\/}/" | paste -s -d ':' -)${LIBRARY_PATH:+:}${LIBRARY_PATH:-}"
-fi
-export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH)=' >"$BUILDPACK_DIR/export"
+export | grep -E -e ' PATH=' >"$BUILDPACK_DIR/export"
 echo 'Done' | indent

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -18,10 +18,8 @@ RSpec.describe "This buildpack" do
         expect(app.output).to match("deployed to Heroku")
 
         expect(app.run("which ffmpeg").strip).to match("/app/.heroku/activestorage-preview/bin/ffmpeg")
-        expect(app.run("which pdftoppm").strip).to match("/app/.heroku/activestorage-preview/usr/bin/pdftoppm")
 
         expect(app.run("ffprobe ./flashlight.mp4").strip).to include("Duration: 00:00:04.44")
-        expect(app.run("pdftoppm -v").strip).to include("pdftoppm version")
       end
     end
   end


### PR DESCRIPTION
Current `main` and `update-ffmpeg` will now fail, as the recent stack image update brought in all the libraries that `poppler-utils` needs as part of the `libvips` install.

As a result, the `find` for `.so` files piped to `xargs dirname` in `bin/compile` will fail, because no `.so` files are actually added:

```
remote: -----> ActiveStorage Preview app detected
remote: -----> Installing binary dependencies for ActiveStorage Preview
remote:        Detected ffmpeg version change, flushing cache
remote:        Downloading packagesW: http://apt.postgresql.org/pub/repos/apt/dists/jammy-pgdg/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
remote: ..
remote:        Installing packages..
remote: dirname: missing operand
remote: Try 'dirname --help' for more information.
remote:  !     Push rejected, failed to compile ActiveStorage Preview app.
remote: 
remote:  !     Push failed
```

This simplifies `bin/compile` greatly by removing all the now-unnecessary Apt trickery:

```
% heroku buildpacks:set -i 1 https://github.com/heroku/heroku-buildpack-activestorage-preview.git#stack-poppler
Buildpack set. Next release on blooming-castle-09486 will use:
  1. https://github.com/heroku/heroku-buildpack-activestorage-preview.git#stack-poppler
  2. heroku/ruby
Run git push heroku main to create a new release using these buildpacks.

% git push heroku master
…
remote: -----> ActiveStorage Preview app detected
remote: -----> Installing binary dependencies for ActiveStorage Preview
remote:        Downloading ffmpeg version 5.1.2
remote:        Installing ffmpeg
remote:        Done
remote:        Exporting environment variables
remote:        Done
…

% heroku run which ffmpeg pdftocairo
Running which ffmpeg pdftocairo on ⬢ blooming-castle-09486... up, run.3697 (Basic)
/app/.heroku/activestorage-preview/bin/ffmpeg
/usr/bin/pdftocairo
```

GUS-W-12618598

Also closes #21 

GUS-W-8276306