### PR TITLE
Fix Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,6 @@
-version: 1
+version: 2
 updates:
   - package-ecosystem: "bundler"
     directory: "/"
-    open-pull-requests-limit: 1 # Limit concurrent CI runs from executing
     schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
+      interval: "monthly"


### PR DESCRIPTION
Resolves:

```
The property '#/version' value 1 did not match one of the following values: 2
```

The PR limit has been removed for this repository, since it's unnecessary (it only has a single test) and slows down trying to update dependencies when we're very behind (eg when I'm trying to update to Hatchet 8.x now).

The explicit label has also been removed for parity with our other repos (the default labels are better).

The cadence has been changed to monthly, for parity with our other repos.