### PR TITLE
Maintenance plus Bundler/GHA version bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       PARALLEL_SPLIT_TEST_PROCESSES: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby and dependencies
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "parallel_split_test"
 gem "heroku_hatchet"
+gem 'rspec-expectations'
 gem "rspec-retry"
 gem "webrick"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem "parallel_split_test"
-gem "heroku_hatchet", github: "heroku/hatchet"
+gem "heroku_hatchet"
 gem "rspec-retry"
 gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    diff-lcs (1.5.1)
     erubis (2.7.0)
     excon (0.110.0)
     heroics (0.1.2)
@@ -29,6 +30,9 @@ GEM
     rrrretry (1.0.0)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.13.1)
@@ -42,6 +46,7 @@ PLATFORMS
 DEPENDENCIES
   heroku_hatchet
   parallel_split_test
+  rspec-expectations
   rspec-retry
   webrick
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,54 +1,38 @@
-GIT
-  remote: https://github.com/heroku/hatchet.git
-  revision: 3f13327a11def454088ffe231bfb2a2c67696be7
-  specs:
-    heroku_hatchet (8.0.1)
-      excon (~> 0)
-      platform-api (~> 3)
-      rrrretry (~> 1)
-      thor (~> 1)
-      threaded (~> 0)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.4.4)
     erubis (2.7.0)
-    excon (0.99.0)
+    excon (0.110.0)
     heroics (0.1.2)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
       webrick
+    heroku_hatchet (8.0.3)
+      excon (~> 0)
+      platform-api (~> 3)
+      rrrretry (~> 1)
+      thor (~> 1)
+      threaded (~> 0)
     moneta (1.0.0)
     multi_json (1.15.0)
-    parallel (1.19.2)
-    parallel_split_test (0.8.0)
+    parallel (1.24.0)
+    parallel_split_test (0.10.0)
       parallel (>= 0.5.13)
-      rspec (>= 3.1.0)
-    platform-api (3.5.0)
+      rspec-core (>= 3.9.0)
+    platform-api (3.7.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
     rate_throttle_client (0.1.2)
     rrrretry (1.0.0)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-support (3.9.3)
-    thor (1.2.1)
+    rspec-support (3.13.1)
+    thor (1.3.1)
     threaded (0.0.4)
     webrick (1.8.1)
 
@@ -56,7 +40,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  heroku_hatchet!
+  heroku_hatchet
   parallel_split_test
   rspec-retry
   webrick

--- a/hatchet.json
+++ b/hatchet.json
@@ -1,11 +1,1 @@
-{
-  "ruby_apps": [
-    "sharpstone/default_ruby"
-  ],
-  "node_apps": [
-    "heroku/node-js-getting-started"
-  ],
-  "python_apps": [
-    "heroku/python-getting-started"
-  ]
-}
+{}

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -1,7 +1,1 @@
----
-- - "./repos/node_apps/node-js-getting-started"
-  - a5d0ca5a618f18948652ebbd20b27b6970293d5c
-- - "./repos/python_apps/python-getting-started"
-  - 3109f8bed0e9fe0b0ad50097ee227485d5475cb9
-- - "./repos/ruby_apps/default_ruby"
-  - 6e642963acec0ff64af51bd6fba8db3c4176ed6e
+--- []

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -3,16 +3,9 @@ require_relative "../spec_helper.rb"
 RSpec.describe "This buildpack" do
   it "has its own tests" do
     # Specify where you want your buildpack to go using :default
-    buildpacks = [:default, "heroku/ruby"]
+    buildpacks = [:default]
 
-    # To deploy a different app modify the hatchet.json or
-    # commit an app to your source control and use a path
-    # instead of "default_ruby" here
-    new_app_with_stack("default_ruby", buildpacks: buildpacks).tap do |app|
-      app.before_deploy do
-        # Modfiy the app here if you need
-        FileUtils.cp(fixtures.join("flashlight.mp4"), "./flashlight.mp4")
-      end
+    new_app_with_stack("spec/fixtures/", buildpacks: buildpacks).tap do |app|
       app.deploy do
         # Assert the behavior you desire here
         expect(app.output).to match("deployed to Heroku")


### PR DESCRIPTION
Now uses "stable" version of `heroku_hatchet`.

Also simplifies test setup to no longer perform a Ruby build (or require a repo download via `hatchet.json`).

Closes #45 
Closes #46 
Closes #48

GUS-W-15917198