### PR TITLE
Fix Hatchet app cleaner

### DIFF
--- a/.github/workflows/hatchet_app_cleaner.yml
+++ b/.github/workflows/hatchet_app_cleaner.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "2.7"
+          ruby-version: 3.1
       - name: Run Hatchet destroy
         # Only apps older than 10 minutes are destroyed, to ensure that any
         # in progress CI runs are not interrupted.


### PR DESCRIPTION
It's currently failing with:

```
excon-1.2.8 requires ruby version >= 3.1.0, which is incompatible with the
current version, 2.7.8
```

e.g.:
https://github.com/heroku/heroku-buildpack-activestorage-preview/actions/runs/16768925048/job/47479582377#step:3:46

The Ruby version has been updated to 3.1, to match that used by the main CI workflow:
https://github.com/heroku/heroku-buildpack-activestorage-preview/blob/e59319e86252dd082391e7b612e4667a3685ea42/.github/workflows/build.yml#L31

GUS-W-19268822.