### PR TITLE
Fix GUSINFO metadata in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default to requesting pull request reviews from the Heroku Languages team.
 #ECCN:Open Source
-#GUSINFO:Languages,Heroku Ruby Platform
+#GUSINFO:Heroku - Languages,Heroku Ruby Platform
 * @heroku/languages
 
 # However, request review from the language owner instead for files that are


### PR DESCRIPTION
Since the Languages team was renamed to `Heroku - Languages` in GUS some time ago.

GUS-W-21708465.